### PR TITLE
Fix iPad simulator build

### DIFF
--- a/DailyOS/ContentView.swift
+++ b/DailyOS/ContentView.swift
@@ -89,42 +89,7 @@ struct ContentView: View {
                 .padding(.horizontal, 24)
 
                 List {
-                    Section {
-                        if viewModel.dayBlocks.isEmpty {
-                            VStack(alignment: .leading, spacing: 10) {
-                                emptyState
-                                Spacer()
-                            }
-                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                            .glassPanel()
-                            .padding(.horizontal, 14)
-                            .padding(.top, 10)
-                            .listRowSeparator(.hidden)
-                            .listRowBackground(Color.clear)
-                        } else {
-                            ForEach(viewModel.dayBlocks) { block in
-                                blockRow(block)
-                                    .contentShape(Rectangle())
-                                    .onTapGesture { editingBlock = block }
-                                    .swipeActions(edge: .trailing) {
-                                        Button { editingBlock = block } label: {
-                                            Label("Edit", systemImage: "pencil")
-                                        }
-                                        Button(role: .destructive) { pendingDeleteBlock = block } label: {
-                                            Label("Delete", systemImage: "trash")
-                                        }
-                                        .listRowSeparator(.hidden)
-                                        .listRowBackground(Color.clear)
-                                }
-                                // NOTE: List reordering only works in Edit mode.
-                                // Keeping the handler here so you can re-enable later if you want.
-                                .onMove(perform: moveTodayBlocks)
-                            }
-                            .onMove(perform: moveTodayBlocks)
-                        }
-                    }
-                    .listStyle(.plain)
-                    .scrollContentBackground(.hidden)
+                    scheduleSection
                 }
                 .listStyle(.plain)
                 .scrollContentBackground(.hidden)
@@ -284,6 +249,46 @@ struct ContentView: View {
         .onAppear {
             viewModel.onAppear()
             showOnboarding = !hasCompletedOnboarding
+        }
+    }
+
+    @ViewBuilder
+    private var scheduleSection: some View {
+        Section {
+            if viewModel.dayBlocks.isEmpty {
+                VStack(alignment: .leading, spacing: 10) {
+                    emptyState
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .glassPanel()
+                .padding(.horizontal, 14)
+                .padding(.top, 10)
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+            } else {
+                ForEach(viewModel.dayBlocks) { block in
+                    blockRow(block)
+                        .contentShape(Rectangle())
+                        .onTapGesture { editingBlock = block }
+                        .swipeActions(edge: .trailing) {
+                            Button {
+                                editingBlock = block
+                            } label: {
+                                Label("Edit", systemImage: "pencil")
+                            }
+
+                            Button(role: .destructive) {
+                                pendingDeleteBlock = block
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                        .listRowSeparator(.hidden)
+                        .listRowBackground(Color.clear)
+                }
+                .onMove(perform: moveTodayBlocks)
+            }
         }
     }
 
@@ -693,27 +698,32 @@ struct AddBlockView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") { dismiss() }
+                    Button(action: { dismiss() }) {
+                        Text("Cancel")
+                    }
                         .cuteBody(weight: .demiBold)
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button("Save") {
+                    Button(action: {
                         let trimmed = activity.trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard !trimmed.isEmpty else { return }
-                        let normalizedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            let normalizedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+                            let fullStart = combine(day: day, time: startTimeOnly)
 
-                        let fullStart = combine(day: day, time: startTimeOnly)
-                        onSave(
-                            ScheduleBlock(
-                                day: day,
-                                activity: trimmed,
-                                startTime: fullStart,
-                                durationMinutes: durationMinutes,
-                                reminderLeadMinutes: reminderLeadMinutes,
-                                notes: normalizedNotes
+                            onSave(
+                                ScheduleBlock(
+                                    day: day,
+                                    activity: trimmed,
+                                    startTime: fullStart,
+                                    durationMinutes: durationMinutes,
+                                    reminderLeadMinutes: reminderLeadMinutes,
+                                    notes: normalizedNotes
+                                )
                             )
-                        )
-                        dismiss()
+                            dismiss()
+                        }
+                    }) {
+                        Text("Save")
                     }
                     .cuteBody(weight: .demiBold)
                     .disabled(activity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -815,29 +825,34 @@ struct EditBlockView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") { dismiss() }
+                    Button(action: { dismiss() }) {
+                        Text("Cancel")
+                    }
                         .cuteBody(weight: .demiBold)
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button("Save") {
+                    Button(action: {
                         let trimmed = activity.trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard !trimmed.isEmpty else { return }
-                        let normalizedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            let normalizedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+                            let fullStart = combine(day: day, time: startTimeOnly)
 
-                        let fullStart = combine(day: day, time: startTimeOnly)
-                        onSave(
-                            ScheduleBlock(
-                                id: original.id,
-                                day: day,
-                                activity: trimmed,
-                                startTime: fullStart,
-                                durationMinutes: durationMinutes,
-                                reminderLeadMinutes: reminderLeadMinutes,
-                                notes: normalizedNotes,
-                                isDone: original.isDone
+                            onSave(
+                                ScheduleBlock(
+                                    id: original.id,
+                                    day: day,
+                                    activity: trimmed,
+                                    startTime: fullStart,
+                                    durationMinutes: durationMinutes,
+                                    reminderLeadMinutes: reminderLeadMinutes,
+                                    notes: normalizedNotes,
+                                    isDone: original.isDone
+                                )
                             )
-                        )
-                        dismiss()
+                            dismiss()
+                        }
+                    }) {
+                        Text("Save")
                     }
                     .cuteBody(weight: .demiBold)
                     .disabled(activity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)

--- a/DailyOS/Domain/ScheduleBlock.swift
+++ b/DailyOS/Domain/ScheduleBlock.swift
@@ -6,6 +6,7 @@ struct ScheduleBlock: Identifiable, Equatable, Codable {
     var activity: String
     var startTime: Date
     var durationMinutes: Int
+    var reminderLeadMinutes: Int
     var notes: String
     var isDone: Bool
 
@@ -15,6 +16,7 @@ struct ScheduleBlock: Identifiable, Equatable, Codable {
         activity: String,
         startTime: Date,
         durationMinutes: Int,
+        reminderLeadMinutes: Int = 10,
         notes: String = "",
         isDone: Bool = false
     ) {
@@ -23,6 +25,7 @@ struct ScheduleBlock: Identifiable, Equatable, Codable {
         self.activity = activity
         self.startTime = startTime
         self.durationMinutes = durationMinutes
+        self.reminderLeadMinutes = reminderLeadMinutes
         self.notes = notes
         self.isDone = isDone
     }
@@ -33,6 +36,7 @@ struct ScheduleBlock: Identifiable, Equatable, Codable {
         case activity
         case startTime
         case durationMinutes
+        case reminderLeadMinutes
         case notes
         case isDone
     }
@@ -44,6 +48,7 @@ struct ScheduleBlock: Identifiable, Equatable, Codable {
         activity = try container.decode(String.self, forKey: .activity)
         startTime = try container.decode(Date.self, forKey: .startTime)
         durationMinutes = try container.decode(Int.self, forKey: .durationMinutes)
+        reminderLeadMinutes = (try? container.decode(Int.self, forKey: .reminderLeadMinutes)) ?? 10
         notes = (try? container.decode(String.self, forKey: .notes)) ?? ""
         isDone = (try? container.decode(Bool.self, forKey: .isDone)) ?? false
         day = Calendar.current.startOfDay(for: day)

--- a/DailyOS/Domain/ScheduleBlockEntity.swift
+++ b/DailyOS/Domain/ScheduleBlockEntity.swift
@@ -8,6 +8,7 @@ final class ScheduleBlockEntity {
     var activity: String = ""
     var startTime: Date = Date()
     var durationMinutes: Int = 30
+    var reminderLeadMinutes: Int = 10
     var notes: String = ""
     var isDone: Bool = false
     var updatedAt: Date = Date()
@@ -18,6 +19,7 @@ final class ScheduleBlockEntity {
         activity: String,
         startTime: Date,
         durationMinutes: Int,
+        reminderLeadMinutes: Int = 10,
         notes: String = "",
         isDone: Bool = false,
         updatedAt: Date = Date()
@@ -27,6 +29,7 @@ final class ScheduleBlockEntity {
         self.activity = activity
         self.startTime = startTime
         self.durationMinutes = durationMinutes
+        self.reminderLeadMinutes = reminderLeadMinutes
         self.notes = notes
         self.isDone = isDone
         self.updatedAt = updatedAt
@@ -39,6 +42,7 @@ final class ScheduleBlockEntity {
             activity: block.activity,
             startTime: block.startTime,
             durationMinutes: block.durationMinutes,
+            reminderLeadMinutes: block.reminderLeadMinutes,
             notes: block.notes,
             isDone: block.isDone,
             updatedAt: Date()
@@ -52,6 +56,7 @@ final class ScheduleBlockEntity {
             activity: activity,
             startTime: startTime,
             durationMinutes: durationMinutes,
+            reminderLeadMinutes: reminderLeadMinutes,
             notes: notes,
             isDone: isDone
         )
@@ -62,6 +67,7 @@ final class ScheduleBlockEntity {
         activity = block.activity
         startTime = block.startTime
         durationMinutes = block.durationMinutes
+        reminderLeadMinutes = block.reminderLeadMinutes
         notes = block.notes
         isDone = block.isDone
         updatedAt = Date()

--- a/DailyOS/Services/ReminderScheduling.swift
+++ b/DailyOS/Services/ReminderScheduling.swift
@@ -17,6 +17,7 @@ actor UserNotificationReminderScheduler: ReminderScheduling {
     private struct ReminderFingerprint: Equatable {
         let activity: String
         let startTime: Date
+        let reminderLeadMinutes: Int
         let isDone: Bool
     }
 
@@ -102,9 +103,14 @@ actor UserNotificationReminderScheduler: ReminderScheduling {
         content.body = "Starts at \(ScheduleFormatters.timeString(block.startTime))"
         content.sound = .default
 
+        let reminderDate = Calendar.current.date(
+            byAdding: .minute,
+            value: -block.reminderLeadMinutes,
+            to: block.startTime
+        ) ?? block.startTime
         let dateComponents = Calendar.current.dateComponents(
             [.year, .month, .day, .hour, .minute],
-            from: block.startTime
+            from: reminderDate
         )
 
         let request = UNNotificationRequest(
@@ -146,6 +152,7 @@ actor UserNotificationReminderScheduler: ReminderScheduling {
         ReminderFingerprint(
             activity: block.activity,
             startTime: block.startTime,
+            reminderLeadMinutes: block.reminderLeadMinutes,
             isDone: block.isDone
         )
     }


### PR DESCRIPTION
## Summary
- restore reminder lead time on schedule blocks and SwiftData entities
- use reminder lead time when scheduling notifications
- simplify the ContentView schedule section and toolbar button closures so the iPad simulator target builds cleanly

## Verification
- build_sim on iPad Air 11-inch (M3) simulator succeeded
- build_run_sim on the same iPad simulator succeeded